### PR TITLE
fix: use valid semver range in pixi.js peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "@rollup/plugin-terser": "^0.4.4"
   },
   "peerDependencies": {
-    "pixi.js": "^7.4.x | ^8.x"
+    "pixi.js": "^7.4.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
Could you publish a new patch release after merging? This blocks npm install without --legacy-peer-deps.