### PR TITLE
Update peer dependency for pixi.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "@rollup/plugin-terser": "^1.0.0"
   },
   "peerDependencies": {
-    "pixi.js": "^7.4.0 || ^8.0.0"
+    "pixi.js": ">=7.4.0 <9"
   }
 }


### PR DESCRIPTION
Using revolt in a pixi 7.4.2 project throws a peer dependency error (below), which the only working workaround is to use the --legacy-peer-deps flag in the npm install command.

The core of the issue seems to be that the peer dependency in the published package `pixi.js@"^7.4.x | ^8.x"` doesn't resolve properly.

```
$ npm i
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: revolt-fx@1.3.5
npm warn Found: pixi.js@7.4.2
npm warn node_modules/pixi.js
npm warn   pixi.js@"7.4.2" from the root project
npm warn
npm warn Could not resolve dependency:
npm warn peer pixi.js@"^7.4.x | ^8.x" from revolt-fx@1.3.5
npm warn node_modules/revolt-fx
npm warn   revolt-fx@"1.3.5" from the root project
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: revolt-fx@1.3.5
npm warn Found: pixi.js@undefined
npm warn node_modules/pixi.js
npm warn   pixi.js@"7.4.2" from the root project
npm warn
npm warn Could not resolve dependency:
npm warn peer pixi.js@"^7.4.x | ^8.x" from revolt-fx@1.3.5
npm warn node_modules/revolt-fx
npm warn   revolt-fx@"1.3.5" from the root project
```